### PR TITLE
Move playfab examples to their own project

### DIFF
--- a/dotnet/SK-dotnet.sln
+++ b/dotnet/SK-dotnet.sln
@@ -150,6 +150,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Planning.StepwisePlanner", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationInsightsExample", "samples\ApplicationInsightsExample\ApplicationInsightsExample.csproj", "{C754950A-E16C-4F96-9CC7-9328E361B5AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlayFabExamples", "samples\PlayFabExamples\PlayFabExamples.csproj", "{948F37AA-A437-4AFF-93C9-03C47A886B5D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -361,6 +363,12 @@ Global
 		{C754950A-E16C-4F96-9CC7-9328E361B5AF}.Publish|Any CPU.ActiveCfg = Release|Any CPU
 		{C754950A-E16C-4F96-9CC7-9328E361B5AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C754950A-E16C-4F96-9CC7-9328E361B5AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{948F37AA-A437-4AFF-93C9-03C47A886B5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{948F37AA-A437-4AFF-93C9-03C47A886B5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{948F37AA-A437-4AFF-93C9-03C47A886B5D}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
+		{948F37AA-A437-4AFF-93C9-03C47A886B5D}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{948F37AA-A437-4AFF-93C9-03C47A886B5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{948F37AA-A437-4AFF-93C9-03C47A886B5D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -413,6 +421,7 @@ Global
 		{677F1381-7830-4115-9C1A-58B282629DC6} = {0247C2C9-86C3-45BA-8873-28B0948EDC0C}
 		{4762BCAF-E1C5-4714-B88D-E50FA333C50E} = {078F96B4-09E1-4E0E-B214-F71A4F4BF633}
 		{C754950A-E16C-4F96-9CC7-9328E361B5AF} = {FA3720F1-C99A-49B2-9577-A940257098BF}
+		{948F37AA-A437-4AFF-93C9-03C47A886B5D} = {FA3720F1-C99A-49B2-9577-A940257098BF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBDC56A3-86AD-4323-AA0F-201E59123B83}

--- a/dotnet/samples/KernelSyntaxExamples/Program.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Program.cs
@@ -19,11 +19,6 @@ public static class Program
         using CancellationTokenSource cancellationTokenSource = new();
         CancellationToken cancelToken = cancellationTokenSource.ConsoleCancellationToken();
 
-        // Run PlayFab Examples
-        await Example00_01_PlayFabDataQnA.RunAsync().SafeWaitAsync(cancelToken);
-        await Example00_02_PlayFabGenerative.RunAsync().SafeWaitAsync(cancelToken);
-        await Example_00_03_OpenApiSkill_PlayFab.RunAsync().SafeWaitAsync(cancelToken);
-
         // Run examples
         await Example01_NativeFunctions.RunAsync().SafeWaitAsync(cancelToken);
         await Example02_Pipeline.RunAsync().SafeWaitAsync(cancelToken);

--- a/dotnet/samples/PlayFabExamples/Common/Configuration/ConfigurationNotFoundException.cs
+++ b/dotnet/samples/PlayFabExamples/Common/Configuration/ConfigurationNotFoundException.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace PlayFabExamples.Common.Configuration;
+public sealed class ConfigurationNotFoundException : Exception
+{
+    public string? Section { get; }
+    public string? Key { get; }
+
+    public ConfigurationNotFoundException(string section, string key)
+        : base($"Configuration key '{section}:{key}' not found")
+    {
+        this.Section = section;
+        this.Key = key;
+    }
+
+    public ConfigurationNotFoundException(string section)
+    : base($"Configuration section '{section}' not found")
+    {
+        this.Section = section;
+    }
+
+    public ConfigurationNotFoundException() : base()
+    {
+    }
+
+    public ConfigurationNotFoundException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}

--- a/dotnet/samples/PlayFabExamples/Common/Configuration/Env.cs
+++ b/dotnet/samples/PlayFabExamples/Common/Configuration/Env.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.Configuration;
+
+namespace PlayFabExamples.Common.Configuration;
+
+#pragma warning disable CA1812 // instantiated by AddUserSecrets
+internal sealed class Env
+#pragma warning restore CA1812
+{
+    /// <summary>
+    /// Simple helper used to load env vars and secrets like credentials,
+    /// to avoid hard coding them in the sample code
+    /// </summary>
+    /// <param name="name">Secret name / Env var name</param>
+    /// <returns>Value found in Secret Manager or Environment Variable</returns>
+    internal static string Var(string name)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddUserSecrets<Env>()
+            .Build();
+
+        var value = configuration[name];
+        if (!string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        value = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new ConfigurationNotFoundException($"Secret / Env var not set: {name}");
+        }
+
+        return value;
+    }
+}

--- a/dotnet/samples/PlayFabExamples/Common/Configuration/TestConfiguration.cs
+++ b/dotnet/samples/PlayFabExamples/Common/Configuration/TestConfiguration.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
+
+namespace PlayFabExamples.Common.Configuration;
+public sealed class TestConfiguration
+{
+    private IConfigurationRoot _configRoot;
+    private static TestConfiguration? s_instance;
+
+    private TestConfiguration(IConfigurationRoot configRoot)
+    {
+        this._configRoot = configRoot;
+    }
+
+    public static void Initialize(IConfigurationRoot configRoot)
+    {
+        s_instance = new TestConfiguration(configRoot);
+    }
+
+    public static AzureOpenAIConfig AzureOpenAI => LoadSection<AzureOpenAIConfig>();
+
+    public static BingConfig Bing => LoadSection<BingConfig>();
+    public static PlayFabConfig PlayFab => LoadSection<PlayFabConfig>();
+
+    private static T LoadSection<T>([CallerMemberName] string? caller = null)
+    {
+        if (s_instance == null)
+        {
+            throw new InvalidOperationException(
+                "TestConfiguration must be initialized with a call to Initialize(IConfigurationRoot) before accessing configuration values.");
+        }
+
+        if (string.IsNullOrEmpty(caller))
+        {
+            throw new ArgumentNullException(nameof(caller));
+        }
+        return s_instance._configRoot.GetSection(caller).Get<T>() ??
+            throw new ConfigurationNotFoundException(section: caller);
+    }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+
+    public class AzureOpenAIConfig
+    {
+        public string ServiceId { get; set; }
+        public string DeploymentName { get; set; }
+        public string ChatDeploymentName { get; set; }
+        public string Endpoint { get; set; }
+        public string ApiKey { get; set; }
+    }
+
+    public class BingConfig
+    {
+        public string ApiKey { get; set; }
+    }
+
+    public class PlayFabConfig
+    {
+        public string Endpoint { get; set; }
+        public string TitleId { get; set; }
+        public string TitleSecretKey { get; set; }
+        public string SwaggerEndpoint { get; set; }
+        public string ReportsCosmosDBEndpoint { get; set; }
+        public string ReportsCosmosDBKey { get; set; }
+        public string ReportsCosmosDBDatabaseName { get; set; }
+        public string ReportsCosmosDBContainerName { get; set; }
+    }
+
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+}

--- a/dotnet/samples/PlayFabExamples/Common/Logging/ConsoleLogger.cs
+++ b/dotnet/samples/PlayFabExamples/Common/Logging/ConsoleLogger.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.Logging;
+
+namespace PlayFabExamples.Common.Logging;
+/// <summary>
+/// Basic logger printing to console
+/// </summary>
+internal static class ConsoleLogger
+{
+    internal static ILogger Logger => LogFactory.CreateLogger<object>();
+
+    private static ILoggerFactory LogFactory => s_loggerFactory.Value;
+
+    private static readonly Lazy<ILoggerFactory> s_loggerFactory = new(LogBuilder);
+
+    private static ILoggerFactory LogBuilder()
+    {
+        return LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Warning);
+
+            // builder.AddFilter("Microsoft", LogLevel.Trace);
+            // builder.AddFilter("Microsoft", LogLevel.Debug);
+            // builder.AddFilter("Microsoft", LogLevel.Information);
+            // builder.AddFilter("Microsoft", LogLevel.Warning);
+            // builder.AddFilter("Microsoft", LogLevel.Error);
+
+            builder.AddFilter("Microsoft", LogLevel.Warning);
+            builder.AddFilter("System", LogLevel.Warning);
+
+            builder.AddConsole();
+        });
+    }
+}

--- a/dotnet/samples/PlayFabExamples/Example01_DataQnA/Example01_DataQnA.cs
+++ b/dotnet/samples/PlayFabExamples/Example01_DataQnA/Example01_DataQnA.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
-using System.Threading.Tasks;
 using Azure.AI.OpenAI;
 using Azure;
 using Microsoft.SemanticKernel;
@@ -13,14 +11,13 @@ using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Planning;
 using Microsoft.SemanticKernel.Reliability;
 using Microsoft.SemanticKernel.SkillDefinition;
-using RepoUtils;
 using Microsoft.Azure.Cosmos;
-using System.Threading;
-using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
-using System.Linq;
 using Newtonsoft.Json;
-using System.Text.Json.Serialization;
+using PlayFabExamples.Common.Configuration;
+using PlayFabExamples.Common.Logging;
+
+namespace PlayFabExamples.Example01_DataQnA;
 
 public enum PlannerType
 {
@@ -30,7 +27,7 @@ public enum PlannerType
 }
 
 // ReSharper disable once InconsistentNaming
-public static partial class Example00_01_PlayFabDataQnA
+public static partial class Example01_DataQnA
 {
     public static Dictionary<string, string> AllTitleReports = null;
 

--- a/dotnet/samples/PlayFabExamples/Example02_Generative/Example02_Generative.cs
+++ b/dotnet/samples/PlayFabExamples/Example02_Generative/Example02_Generative.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.Planning;
-using Microsoft.SemanticKernel.Skills.Core;
-using RepoUtils;
+using PlayFabExamples.Common.Configuration;
+using PlayFabExamples.Common.Logging;
 
-public static class Example00_02_PlayFabGenerative
+namespace PlayFabExamples.Example02_Generative;
+public static class Example02_Generative
 {
     public static async Task RunAsync()
     {
@@ -42,7 +41,7 @@ public static class Example00_02_PlayFabGenerative
         Console.WriteLine("======== Action Planner ========");
         var kernel = new KernelBuilder()
             .WithLogger(ConsoleLogger.Logger)
-            .WithAzureTextCompletionService(TestConfiguration.AzureOpenAITextDavinci.DeploymentName, TestConfiguration.AzureOpenAITextDavinci.Endpoint, TestConfiguration.AzureOpenAITextDavinci.ApiKey)
+            .WithAzureTextCompletionService(TestConfiguration.AzureOpenAI.DeploymentName, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey)
             .Build();
 
         kernel.ImportSkill(new SegmentSkill(), "SegmentSkill");

--- a/dotnet/samples/PlayFabExamples/Example02_Generative/SegmentSkill.cs
+++ b/dotnet/samples/PlayFabExamples/Example02_Generative/SegmentSkill.cs
@@ -1,19 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Net.Http;
-using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
 using Newtonsoft.Json;
-using RepoUtils;
+using PlayFabExamples.Common.Configuration;
+using PlayFabExamples.Common.Logging;
 
-namespace Microsoft.SemanticKernel.Skills.Core;
+namespace PlayFabExamples.Example02_Generative;
 
 /// <summary>
 /// Create a segment with given information.

--- a/dotnet/samples/PlayFabExamples/Example03_SegmentQuery/Example03_SegmentQuery.cs
+++ b/dotnet/samples/PlayFabExamples/Example03_SegmentQuery/Example03_SegmentQuery.cs
@@ -1,22 +1,21 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Orchestration;
 using Microsoft.SemanticKernel.SkillDefinition;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Authentication;
 using Microsoft.SemanticKernel.Skills.OpenAPI.Extensions;
 using Newtonsoft.Json;
-using RepoUtils;
+using PlayFabExamples.Common.Configuration;
+using PlayFabExamples.Common.Logging;
+
+namespace PlayFabExamples.Example03_SegmentQuery;
 
 /// <summary>
 /// This example shows how to import PlayFab APIs as skills.
 /// </summary>
 // ReSharper disable once InconsistentNaming
-public static class Example_00_03_OpenApiSkill_PlayFab
+public static class Example03_SegmentQuery
 {
     public static async Task RunAsync()
     {

--- a/dotnet/samples/PlayFabExamples/PlayFabExamples.csproj
+++ b/dotnet/samples/PlayFabExamples/PlayFabExamples.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>11</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>4447f5a3-3bc4-4697-a289-b87c718828fc</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Polly" />
+    <PackageReference Include="System.Linq.Async" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Connectors\Connectors.AI.OpenAI\Connectors.AI.OpenAI.csproj" />
+    <ProjectReference Include="..\..\src\Extensions\Planning.ActionPlanner\Planning.ActionPlanner.csproj" />
+    <ProjectReference Include="..\..\src\Extensions\Planning.SequentialPlanner\Planning.SequentialPlanner.csproj" />
+    <ProjectReference Include="..\..\src\Extensions\Planning.StepwisePlanner\Planning.StepwisePlanner.csproj" />
+    <ProjectReference Include="..\..\src\PF-Extensions\Planning.ChatStepwisePlanner\Planning.ChatStepwisePlanner.csproj" />
+    <ProjectReference Include="..\..\src\SemanticKernel.Abstractions\SemanticKernel.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Skills\Skills.Core\Skills.Core.csproj" />
+    <ProjectReference Include="..\..\src\Skills\Skills.OpenAPI\Skills.OpenAPI.csproj" />
+    <ProjectReference Include="..\..\src\SemanticKernel\SemanticKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/samples/PlayFabExamples/Program.cs
+++ b/dotnet/samples/PlayFabExamples/Program.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.Configuration;
+using PlayFabExamples.Common.Configuration;
+
+namespace PlayFabExamples;
+
+public static class Program
+{
+    public static async Task Main(string[] args)
+    {
+        // Load configuration from environment variables or user secrets.
+        LoadUserSecrets();
+
+        // Execution canceled if the user presses Ctrl+C.
+        using CancellationTokenSource cancellationTokenSource = new();
+        CancellationToken cancelToken = cancellationTokenSource.ConsoleCancellationToken();
+
+        // Run PlayFab Examples
+        await PlayFabExamples.Example01_DataQnA.Example01_DataQnA.RunAsync().SafeWaitAsync(cancelToken);
+        await PlayFabExamples.Example02_Generative.Example02_Generative.RunAsync().SafeWaitAsync(cancelToken);
+        await PlayFabExamples.Example03_SegmentQuery.Example03_SegmentQuery.RunAsync().SafeWaitAsync(cancelToken);
+    }
+
+    private static void LoadUserSecrets()
+    {
+        IConfigurationRoot configRoot = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<Env>()
+            .Build();
+        TestConfiguration.Initialize(configRoot);
+    }
+
+    private static CancellationToken ConsoleCancellationToken(this CancellationTokenSource tokenSource)
+    {
+        Console.CancelKeyPress += (s, e) =>
+        {
+            Console.WriteLine("Canceling...");
+            tokenSource.Cancel();
+            e.Cancel = true;
+        };
+
+        return tokenSource.Token;
+    }
+
+    private static async Task SafeWaitAsync(this Task task,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await task.WaitAsync(cancellationToken);
+            Console.WriteLine("== DONE ==");
+        }
+        catch (ConfigurationNotFoundException ex)
+        {
+            Console.WriteLine($"{ex.Message}. Skipping example.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+}


### PR DESCRIPTION
Moving playfab examples to their own project

<img width="191" alt="image" src="https://github.com/microsoft/semantic-kernel/assets/28154496/e297e6ae-9ae1-4dac-a6f0-326a9f40fcaa">


<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
